### PR TITLE
Error handling for parser

### DIFF
--- a/lib/embulk/guess/query_string.rb
+++ b/lib/embulk/guess/query_string.rb
@@ -13,7 +13,7 @@ module Embulk
           strip_whitespace: config.param("strip_whitespace", :bool, default: true)
         }
         records = sample_lines.map do |line|
-          Parser::QueryString.parse(line, options)
+          Parser::QueryString.parse(line, options) || {}
         end
         format = records.inject({}) do |result, record|
           record.each_pair do |key, value|

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -60,6 +60,9 @@ module Embulk
         lines = buffer.lines
         lines.each do |line|
           record = self.class.parse(line, @options)
+
+          next unless record
+
           records = schema.map do |column|
             record[column.name]
           end

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -46,7 +46,12 @@ module Embulk
         if options[:strip_quote]
           line = line[/\A(?:["'])?(.*?)(?:["'])?\z/, 1]
         end
-        Hash[URI.decode_www_form(line)]
+
+        begin
+          Hash[URI.decode_www_form(line)]
+        rescue ArgumentError
+          nil
+        end
       end
 
       private

--- a/test/embulk/guess/test_query_string.rb
+++ b/test/embulk/guess/test_query_string.rb
@@ -37,6 +37,21 @@ module Embulk
           }
           assert_equal(expected, actual)
         end
+
+        def test_guess_with_invalid
+          actual = QueryString.new.guess_lines(config, sample_lines_with_invalid)
+          expected = {
+            "parser" => {
+              type: "query_string",
+              schema: [
+                {name: "foo", type: :long},
+                {name: "bar", type: :string},
+                {name: "baz", type: :string},
+              ]
+            }
+          }
+          assert_equal(expected, actual)
+        end
       end
 
       private
@@ -52,6 +67,14 @@ module Embulk
         [
           %Q(foo=1&bar=vv&baz=3&hoge=999),
           %Q(foo=2&bar=ss&baz=a&xxx=ABC),
+        ]
+      end
+
+      def sample_lines_with_invalid
+        [
+          %Q(foo=1&bar=vv&baz=3),
+          %Q(this=line=is=invalid),
+          %Q(foo=2&bar=ss&baz=a),
         ]
       end
 

--- a/test/embulk/guess/test_query_string.rb
+++ b/test/embulk/guess/test_query_string.rb
@@ -6,48 +6,22 @@ module Embulk
   module Guess
     class QueryStringTest < Test::Unit::TestCase
       class TestGuessLines < self
-        def test_guess_1
-          actual = QueryString.new.guess_lines(config, sample_lines_1)
-          expected = {
-            "parser" => {
-              type: "query_string",
-              schema: [
-                {name: "foo", type: :long},
-                {name: "bar", type: :string},
-                {name: "baz", type: :string},
-              ]
-            }
+        data do
+          {
+            same_keys: [sample_lines_with_same_keys, schema_with_same_keys],
+            different_keys: [sample_lines_with_different_keys, schema_with_different_keys],
+            invalid: [sample_lines_with_invalid, schema_with_invalid],
+
           }
-          assert_equal(expected, actual)
         end
 
-        def test_guess_2
-          actual = QueryString.new.guess_lines(config, sample_lines_2)
+        def test_guess(data)
+          sample_lines, schema = data
+          actual = QueryString.new.guess_lines(config, sample_lines)
           expected = {
             "parser" => {
               type: "query_string",
-              schema: [
-                {name: "foo", type: :long},
-                {name: "bar", type: :string},
-                {name: "baz", type: :string},
-                {name: "hoge", type: :long},
-                {name: "xxx", type: :string},
-              ]
-            }
-          }
-          assert_equal(expected, actual)
-        end
-
-        def test_guess_with_invalid
-          actual = QueryString.new.guess_lines(config, sample_lines_with_invalid)
-          expected = {
-            "parser" => {
-              type: "query_string",
-              schema: [
-                {name: "foo", type: :long},
-                {name: "bar", type: :string},
-                {name: "baz", type: :string},
-              ]
+              schema: schema
             }
           }
           assert_equal(expected, actual)
@@ -56,26 +30,50 @@ module Embulk
 
       private
 
-      def sample_lines_1
-        [
-          %Q(foo=1&bar=vv&baz=3),
-          %Q(foo=2&bar=ss&baz=a),
-        ]
-      end
+      class << self
+        def sample_lines_with_same_keys
+          [
+            %Q(foo=1&bar=vv&baz=3),
+            %Q(foo=2&bar=ss&baz=a),
+          ]
+        end
 
-      def sample_lines_2
-        [
-          %Q(foo=1&bar=vv&baz=3&hoge=999),
-          %Q(foo=2&bar=ss&baz=a&xxx=ABC),
-        ]
-      end
+        def schema_with_same_keys
+          [
+            {name: "foo", type: :long},
+            {name: "bar", type: :string},
+            {name: "baz", type: :string},
+          ]
+        end
 
-      def sample_lines_with_invalid
-        [
-          %Q(foo=1&bar=vv&baz=3),
-          %Q(this=line=is=invalid),
-          %Q(foo=2&bar=ss&baz=a),
-        ]
+        def sample_lines_with_different_keys
+          [
+            %Q(foo=1&bar=vv&baz=3&hoge=999),
+            %Q(foo=2&bar=ss&baz=a&xxx=ABC),
+          ]
+        end
+
+        def schema_with_different_keys
+          [
+            {name: "foo", type: :long},
+            {name: "bar", type: :string},
+            {name: "baz", type: :string},
+            {name: "hoge", type: :long},
+            {name: "xxx", type: :string},
+          ]
+        end
+
+        def sample_lines_with_invalid
+          [
+            %Q(foo=1&bar=vv&baz=3),
+            %Q(this=line=is=invalid),
+            %Q(foo=2&bar=ss&baz=a),
+          ]
+        end
+
+        def schema_with_invalid
+          schema_with_same_keys
+        end
       end
 
       def task

--- a/test/embulk/parser/test_query_string_plugin.rb
+++ b/test/embulk/parser/test_query_string_plugin.rb
@@ -67,7 +67,11 @@ module Embulk
         end
 
         def buffer
-          "foo=FOO&bar=1\nfoo=Foo&bar=2"
+          <<-BUFFER
+foo=FOO&bar=1
+foo=Foo&bar=2
+this=line=is=ignored
+          BUFFER
         end
       end
 

--- a/test/embulk/parser/test_query_string_plugin.rb
+++ b/test/embulk/parser/test_query_string_plugin.rb
@@ -21,6 +21,11 @@ module Embulk
           assert_equal(expected, result)
         end
 
+        def test_with_invalid
+          result = QueryString.parse(invalid_line)
+          assert_nil(result)
+        end
+
         private
 
         def expected
@@ -37,6 +42,10 @@ module Embulk
 
         def indented_line
           %Q(  #{line})
+        end
+
+        def invalid_line
+          "invalid=www=form"
         end
       end
 


### PR DESCRIPTION
`URI.decode_www_form` with invalid line (ex. `"this=is=invalid"` )  raises `ArgumentError`, so This commits add error handling for it.
