### PR TITLE
Fix guess: fall back to guess csv

### DIFF
--- a/lib/embulk/guess/query_string.rb
+++ b/lib/embulk/guess/query_string.rb
@@ -8,6 +8,8 @@ module Embulk
       Plugin.register_guess("query_string", self)
 
       def guess_lines(config, sample_lines)
+        return {} unless config.fetch("parser", {}).fetch("type", "query_string") == "query_string"
+
         options = {
           strip_quote: config.param("strip_quote", :bool, default: true),
           strip_whitespace: config.param("strip_whitespace", :bool, default: true)


### PR DESCRIPTION
In current guess implementation, when it tries to read and guess normal CSV files, it fails like following:

```
Caused by: org.jruby.exceptions.RaiseException: (ArgumentError) invalid data of application/x-www-form-urlencoded (date,foo,bar)
    at RUBY.decode_www_form(jruby-complete-1.7.19.jar!/META-INF/jruby.home/lib/ruby/1.9/uri/common.rb:975)
    at RUBY.parse(gems/embulk-parser-query-string-0.0.1/lib/embulk/parser/query-string.rb:49)
    at RUBY.guess_lines(gems/embulk-parser-query-string-0.0.1/lib/embulk/guess/query-string.rb:16)
    at org.jruby.RubyArray.map(org/jruby/RubyArray.java:2412)
    at RUBY.guess_lines(gems/embulk-parser-query-string-0.0.1/lib/embulk/guess/query-string.rb:15)
    at RUBY.guess(file:embulk-core-0.6.10.jar!/embulk/guess_plugin.rb:121)
    at RUBY.guess(file:embulk-core-0.6.10.jar!/embulk/guess_plugin.rb:25)
    at Embulk$$GuessPlugin$$JavaAdapter_1344629918.guess(Embulk$$GuessPlugin$$JavaAdapter_1344629918.gen:13)
```

I think that it's better to fall back to guess csv parser type.
