### PR TITLE
Support embulk 0.6.10 (backward compatibility)

### DIFF
--- a/embulk-parser-query_string.gemspec
+++ b/embulk-parser-query_string.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'embulk', [">= 0.6.13", "< 1.0"]
+  spec.add_development_dependency 'embulk', [">= 0.6.10", "< 1.0"]
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']
   spec.add_development_dependency 'pry'

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -10,13 +10,13 @@ module Embulk
         decoder_task = config.load_config(Java::LineDecoder::DecoderTask)
 
         task = {
-          decoder: DataSource.from_java(decoder_task.dump),
-          strip_quote: config.param("strip_quote", :bool, default: true),
-          strip_whitespace: config.param("strip_whitespace", :bool, default: true),
+          "decoder" => DataSource.from_java(decoder_task.dump),
+          "strip_quote" => config.param("strip_quote", :bool, default: true),
+          "strip_whitespace" => config.param("strip_whitespace", :bool, default: true),
         }
 
         columns = []
-        schema = config.param(:schema, :array, default: [])
+        schema = config.param("schema", :array, default: [])
         schema.each do |column|
           name = column["name"]
           type = column["type"].to_sym
@@ -29,11 +29,11 @@ module Embulk
 
       def init
         @options = {
-          strip_quote: task[:strip_quote],
-          strip_whitespace: task[:strip_whitespace],
+          strip_quote: task["strip_quote"],
+          strip_whitespace: task["strip_whitespace"],
         }
 
-        @decoder = task.param(:decoder, :hash).load_task(Java::LineDecoder::DecoderTask)
+        @decoder = task.param("decoder", :hash).load_task(Java::LineDecoder::DecoderTask)
       end
 
       def run(file_input)

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -77,6 +77,8 @@ module Embulk
           case column.type
           when :long
             Integer(value)
+          when :timestamp
+            Time.parse(value)
           else
             value.to_s
           end

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -70,7 +70,7 @@ module Embulk
         return unless record
 
         # NOTE: this conversion is needless afrer Embulk 0.6.13
-        records = schema.map do |column|
+        values = schema.map do |column|
           name = column.name
           value = record[name]
 
@@ -83,7 +83,8 @@ module Embulk
             value.to_s
           end
         end
-        page_builder.add(records)
+
+        page_builder.add(values)
       end
     end
   end

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -69,8 +69,17 @@ module Embulk
 
         return unless record
 
+        # NOTE: this conversion is needless afrer Embulk 0.6.13
         records = schema.map do |column|
-          record[column.name]
+          name = column.name
+          value = record[name]
+
+          case column.type
+          when :long
+            Integer(value)
+          else
+            value.to_s
+          end
         end
         page_builder.add(records)
       end

--- a/test/embulk/guess/test_query_string.rb
+++ b/test/embulk/guess/test_query_string.rb
@@ -44,7 +44,7 @@ module Embulk
         def test_type(data)
           type, expected = data
           sample_lines = self.class.sample_lines_with_same_keys
-          config = DataSource[{parser: {type: type}}]
+          config = DataSource[{"parser" => {"type" => type}}]
 
           actual = QueryString.new.guess_lines(config, sample_lines)
           assert_equal(expected, actual)

--- a/test/embulk/parser/test_query_string_plugin.rb
+++ b/test/embulk/parser/test_query_string_plugin.rb
@@ -72,10 +72,11 @@ module Embulk
       end
 
       def test_transaction
+        expected_task = task.dup
+        expected_task.delete("schema")
+
         QueryString.transaction(config) do |actual_task, actual_columns|
-          t = task.dup
-          t.delete(:schema)
-          assert_equal(t, actual_task)
+          assert_equal(expected_task, actual_task)
           assert_equal(schema, actual_columns)
         end
       end
@@ -92,10 +93,10 @@ module Embulk
 
       def task
         {
-          decoder: {"Charset" => "UTF-8", "Newline" => "CRLF"},
-          strip_quote: true,
-          strip_whitespace: true,
-          schema: columns,
+          "decoder" => {"Charset" => "UTF-8", "Newline" => "CRLF"},
+          "strip_quote" => true,
+          "strip_whitespace" => true,
+          "schema" => columns,
         }
       end
 

--- a/test/embulk/parser/test_query_string_plugin.rb
+++ b/test/embulk/parser/test_query_string_plugin.rb
@@ -51,14 +51,14 @@ module Embulk
 
       class TestProcessBuffer < self
         def test_process_line
-          mock(page_builder).add(["FOO", 1, Time.parse("2015-07-08T16:25:46+09:00")])
+          mock(page_builder).add(["FOO", 1, Time.parse("2015-07-08T16:25:46+00:00")])
           plugin.send(:process_line, line)
         end
 
         private
 
         def line
-          "foo=FOO&bar=1&baz=2015-07-08T16:25:46+09:00"
+          "foo=FOO&bar=1&baz=2015-07-08T16:25:46+00:00"
         end
       end
 

--- a/test/embulk/parser/test_query_string_plugin.rb
+++ b/test/embulk/parser/test_query_string_plugin.rb
@@ -51,15 +51,14 @@ module Embulk
 
       class TestProcessBuffer < self
         def test_process_line
-          mock(page_builder).add(["FOO", 1])
-
+          mock(page_builder).add(["FOO", 1, Time.parse("2015-07-08T16:25:46+09:00")])
           plugin.send(:process_line, line)
         end
 
         private
 
         def line
-          "foo=FOO&bar=1"
+          "foo=FOO&bar=1&baz=2015-07-08T16:25:46+09:00"
         end
       end
 
@@ -96,6 +95,7 @@ module Embulk
         [
           {"name" => "foo", "type" => :string},
           {"name" => "bar", "type" => :long},
+          {"name" => "baz", "type" => :timestamp},
         ]
       end
 

--- a/test/embulk/parser/test_query_string_plugin.rb
+++ b/test/embulk/parser/test_query_string_plugin.rb
@@ -51,20 +51,12 @@ module Embulk
 
       class TestProcessBuffer < self
         def test_process_line
-          records.each do |record|
-            mock(page_builder).add(record.values)
-          end
+          mock(page_builder).add(["FOO", 1])
 
           plugin.send(:process_line, line)
         end
 
         private
-
-        def records
-          [
-            {"foo" => "FOO", "bar" => "1"},
-          ]
-        end
 
         def line
           "foo=FOO&bar=1"
@@ -102,8 +94,8 @@ module Embulk
 
       def columns
         [
-          {"name" => "foo", "type" => "string"},
-          {"name" => "bar", "type" => "string"},
+          {"name" => "foo", "type" => :string},
+          {"name" => "bar", "type" => :long},
         ]
       end
 


### PR DESCRIPTION
- use String key to fetch value from config/task (Symbol access is supported by embulk 0.6.12 or later) 
- convert values added to page_builder (this feature is supported by embulk 0.6.13 or lator)
- support timestamp by parser
