### PR TITLE
Fix same name tests weren't run

### DIFF
--- a/test/embulk/parser/test_query_string.rb
+++ b/test/embulk/parser/test_query_string.rb
@@ -4,7 +4,7 @@ require "embulk/data_source"
 
 module Embulk
   module Parser
-    class QueryStringPluginTest < Test::Unit::TestCase
+    class QueryStringTest < Test::Unit::TestCase
       class TestParse < self
         def test_without_options
           result = QueryString.parse(line)

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -15,4 +15,4 @@ ENV["TEST_UNIT_MAX_DIFF_TARGET_STRING_SIZE"] ||= "5000"
 
 CodeClimate::TestReporter.start
 
-exit Test::Unit::AutoRunner.run(true, test_dir)
+exit Test::Unit::AutoRunner.run(true, test_dir, ARGV + %w(--collector=dir))


### PR DESCRIPTION
`--collector=load` (default) cannot require the test files they are same filename in different directories.
`--collector=dir` solves it.
