### PR TITLE
Display cast error log to human

### DIFF
--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -84,13 +84,18 @@ module Embulk
 
           next nil unless value
 
-          case column.type
-          when :long
-            value.strip.empty? ? nil : Integer(value)
-          when :timestamp
-            value.strip.empty? ? nil : Time.parse(value)
-          else
-            value.to_s
+          begin
+            case column.type
+            when :long
+              value.strip.empty? ? nil : Integer(value)
+            when :timestamp
+              value.strip.empty? ? nil : Time.parse(value)
+            else
+              value.to_s
+            end
+          rescue => e
+            Embulk.logger.error "Cast failed '#{value}' as '#{column.type}' (key is '#{column.name}')"
+            raise e
           end
         end
 


### PR DESCRIPTION
```
org.embulk.exec.PartialExecutionException: org.jruby.exceptions.RaiseException: (ArgumentError) invalid value for Integer: "2739.7"
        at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:331)
```

↓

```
2015-07-28 11:11:13.212 +0900 [ERROR] (task-0000): Cast failed '2739.7' as 'long' (key is 'aid')
```
