### PR TITLE
travis: use jruby-9.0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 rvm:
 - jruby-9000
+
+before_install:
+- rvm get head
+- rvm use jruby-9.0.1.0 --install
+
 addons:
   code_climate:
     repo_token:


### PR DESCRIPTION
Use `jruby-9.0.1.0` in Travis with rvm.
In more detail, please refer to this issue: https://github.com/travis-ci/travis-ci/issues/4720

And why not request to Travis to support `jruby-9.0.1.0`?
