### PR TITLE
Use addressable gem to parse uri

### DIFF
--- a/embulk-parser-query_string.gemspec
+++ b/embulk-parser-query_string.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'addressable'
   spec.add_development_dependency 'embulk', [">= 0.7.2", "< 1.0"]
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'everyleaf-embulk_helper'

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -1,4 +1,4 @@
-require "uri"
+require "addressable/uri"
 
 module Embulk
   module Parser
@@ -64,7 +64,8 @@ module Embulk
         end
 
         begin
-          Hash[URI.decode_www_form(line)]
+          uri = Addressable::URI.parse("?#{line}")
+          uri.query_values(Hash)
         rescue ArgumentError
           Embulk.logger.warn "Failed parse: #{line}"
           nil

--- a/lib/embulk/parser/query_string.rb
+++ b/lib/embulk/parser/query_string.rb
@@ -50,6 +50,20 @@ module Embulk
         page_builder.finish
       end
 
+      def self.valid_query_string?(qs)
+        if qs.match(/[\s]/)
+          Embulk.logger.warn "'#{qs}' contains unescaped space"
+          return false
+        end
+
+        if qs.match(/[^\x20-\x7e]/)
+          Embulk.logger.warn "'#{qs}' contains non-ascii character (maybe unescaped)"
+          return false
+        end
+
+        true
+      end
+
       def self.parse(line, options = {})
         if options[:capture]
           line = line.match(options[:capture]).to_a[1] || ""
@@ -65,7 +79,11 @@ module Embulk
 
         begin
           uri = Addressable::URI.parse("?#{line}")
-          uri.query_values(Hash)
+          if valid_query_string?(uri.query)
+            uri.query_values(Hash)
+          else
+            nil
+          end
         rescue ArgumentError
           Embulk.logger.warn "Failed parse: #{line}"
           nil

--- a/test/embulk/guess/test_query_string.rb
+++ b/test/embulk/guess/test_query_string.rb
@@ -30,7 +30,7 @@ module Embulk
         end
 
         def test_warn_invalid_columns
-          mock(Embulk.logger).warn(/Failed parse/)
+          mock(Embulk.logger).warn(anything)
 
           QueryString.new.guess_lines(config, self.class.sample_lines_with_invalid)
         end

--- a/test/embulk/parser/test_query_string.rb
+++ b/test/embulk/parser/test_query_string.rb
@@ -32,7 +32,7 @@ module Embulk
         end
 
         def test_with_invalid
-          mock(Embulk.logger).warn(/#{invalid_line}/) # display whole line if given line is invalid
+          mock(Embulk.logger).warn(/'#{invalid_line}'/) # display whole line if given line is invalid
           result = QueryString.parse(invalid_line)
           assert_nil(result)
         end


### PR DESCRIPTION
Current implementation is rely on Ruby's stdlib URI and `URI.decode_www_form` behavior was changed from Ruby 1.9 to 2.x.
That is uncontrollable to us as a plugin developer.

And additional wants is that we want to detect query string that _looks_ invalid e.g. unescaped character contains.

Using addressable gem is Ruby's version free and we can fix that version.
